### PR TITLE
Fixed correlation reference

### DIFF
--- a/assets/lectures/lecture5-slr/7-2_least_square_reg/7-2_least_square_reg.tex
+++ b/assets/lectures/lecture5-slr/7-2_least_square_reg/7-2_least_square_reg.tex
@@ -607,7 +607,7 @@ e &= \%~in~poverty - \widehat{\%~in~poverty} \\
 
 \pause
 
-\item For the model we've been working with, $R^2 = -0.62^2 = 0.38$.
+\item For the model we've been working with, $R^2 = -0.75^2 = 0.5625$.
 
 \end{itemize}
 


### PR DESCRIPTION
I believe the slide incorrectly referenced an R value of 0.62, which was actually our beta1 calculation. Slide 32 indicates a correlation R of -0.75.